### PR TITLE
Word count - updated to work in current Standard Notes client

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,8 @@ module.exports = function(grunt) {
         separator: ';',
       },
       app: {
-        src: ['app/js/**/*.js'],
+        src: [ 'node_modules/sn-components-api/src/componentManager.js'
+             , 'app/js/**/*.js' ],
         dest: 'dist/app.js',
       },
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,0 +1,27 @@
+# Word Counter
+
+This is a very simple sample extension for Standard Notes.
+
+## Building
+
+To build the extension, run the following commands:
+
+1. `npm install`
+2. `grunt`
+3. Host the local directory. In python 3: `python -m http.server --bind localhost 8000`
+
+## Installing
+
+1. To install the component in Standard Notes you need to provide a json manifest from the URL. The included `extension.json` file will be used for this sample. It assumes you are hosting the extension at `http://localhost:8000` (production extensions should be hosted over https). At minimum this file should include:
+    * identifier - a unique identifier for your extension.
+    * name - the name of the extension.
+    * content_type - the type of component.
+    * area - the area the component should be added to.
+    * url - the hosted url of the extension.
+
+2. Open the Extensions menu, click Install Extension, enter the link to the json file (`http://localhost:8000/extension.json`) in the text box, and press enter. This will show you information about the extension, press Install to complete installation.
+    * You will get an error installing locally if you don't manually create the zip file mentioned in the manifest. This won't affect your usage unless you want to run the extension without hosting it on the local URL.
+
+3. Activate the extension and confirm the permission prompt to allow it to activate.
+
+4. You will now have a word count displayed at the bottom of the editor.

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,14 @@
+{
+  "identifier": "example.word-counter",
+  "name": "Word Counter",
+  "content_type": "SN|Component",
+  "area": "editor-stack",
+  "version": "1.0.0",
+  "description": "An example word counter.",
+  "url": "http://localhost:8000",
+  "download_url": "http://localhost:8000/example.zip",
+  "marketing_url": "",
+  "thumbnail_url": "",
+  "valid_until": "9999-12-31T00:00:00.000Z",
+  "latest_url": ""
+}

--- a/package.json
+++ b/package.json
@@ -2,21 +2,22 @@
   "name": "blank-slate",
   "version": "1.0.0",
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-contrib-cssmin": "^1.0.2",
-    "grunt-contrib-watch": "^1.0.0",
-    "grunt-haml2html": "^0.3.1",
-    "grunt-newer": "^1.2.0",
-    "grunt-contrib-sass": "^1.0.0",
     "angular": "^1.6.1",
     "babel-cli": "^6.18.0",
     "babel-preset-env": "^1.1.1",
     "babel-preset-es2016": "^6.16.0",
+    "grunt": "^1.0.1",
     "grunt-angular-templates": "^1.1.0",
     "grunt-babel": "^6.0.0",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-cssmin": "^1.0.2",
+    "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-uglify": "^2.0.0",
-    "grunt-ng-annotate": "^3.0.0"
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-haml2html": "^0.3.1",
+    "grunt-newer": "^1.2.0",
+    "grunt-ng-annotate": "^3.0.0",
+    "sn-components-api": "^1.0.246"
   }
 }


### PR DESCRIPTION
The existing sample was broken in the current build of Standard Notes (2.1.26), which this fixes. The problems I ran into with the existing sample were:

1. Install Extension seems to now require a json response, which was not provided by index.html. I created an extension.json file which can be used to get the extension information to Extension Manager with the url http://localhost:8000/extension.json.

2. Once installed, the extension failed to run because window.ComponentManager was not defined. I fixed this by added sn-components-api as a dependency, and then updating the Gruntfile to include the api's componentManager.js file in the concat to app.js section.

3. Added a readme with install instructions.

(Looking at my diff now I probably changed all the line ends in the Gruntfile. Sorry about that, it should just be an add of line 61.)